### PR TITLE
OctoberCMS v3 / TWIG 3 Support

### DIFF
--- a/partials/staticmenu/items.htm
+++ b/partials/staticmenu/items.htm
@@ -1,4 +1,4 @@
-{% for item in items if not item.viewBag.isHidden %}
+{% for item in items %}
     {% if not item.viewBag.isHidden %}
         <div class="block mt-4 {{ isSubnav ? 'block' : 'lg:inline-block mr-8' }} lg:mt-0 {{ item.items ? 'has-children' : '' }}">
             {% if item.url %}


### PR DESCRIPTION
Hello,

Twig 3 [dropped for ... if statements](https://github.com/twigphp/Twig/blob/3.x/CHANGELOG#L139), which makes this theme unusable on October CMS v3 installations.

This change is compatible with Twig 2, of course.

Sincerely,
Sam.